### PR TITLE
Add support for Hack Club colors and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ export default () => (
 
 `https://icons.hackclub.com/api/icons/:color/:glyph`
  - `:glyph` - A glyph from [icons.hackclub.com](https://icons.hackclub.com).
- - `:color` - Any valid HTML color. Replace `#` with `0x` when using a hexadecimal color.
+ - `:color` - Any valid HTML color or [Hack Club Theme](https://theme.hackclub.com) color prefixed with `hackclub-`. Replace `#` with `0x` when using a hexadecimal color.
+
+All responses are SVGs with the MIME type `image/svg+xml`. You can optionally include the .svg file extension.
 
 Examples:
 
 ```html
 <img src="https://icons.hackclub.com/api/icons/red/clubs">
-<img src="https://icons.hackclub.com/api/icons/0x33d6a6/battery-bolt">
+<img src="https://icons.hackclub.com/api/icons/hackclub-green/battery-bolt">
+<img src="https://icons.hackclub.com/api/icons/0xc78ad4/sam">
 ```
 
 ## Development Setup

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Examples:
 ```html
 <img src="https://icons.hackclub.com/api/icons/red/clubs">
 <img src="https://icons.hackclub.com/api/icons/hackclub-green/battery-bolt">
-<img src="https://icons.hackclub.com/api/icons/0xc78ad4/sam">
+<img src="https://icons.hackclub.com/api/icons/0xc78ad4/sam.svg">
 ```
 
 ## Development Setup

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@hackclub/icons": "latest",
+    "@hackclub/theme": "^0.3.3",
     "next": "^10.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/docs/pages/api/icons/[color]/[glyph].js
+++ b/docs/pages/api/icons/[color]/[glyph].js
@@ -1529,6 +1529,7 @@ export default async function handler(request, response) {
     else if (color.startsWith('0x') && color.length === 8) color = '#' + color.substring(2);
 
     response.setHeader('Content-Type', 'image/svg+xml');
+    response.setHeader('Cache-Control', 's-maxage=86400');
     response.end(IconLibrary.icon(glyph, 256, color));
 }
 

--- a/docs/pages/api/icons/[color]/[glyph].js
+++ b/docs/pages/api/icons/[color]/[glyph].js
@@ -1,3 +1,5 @@
+import theme from '@hackclub/theme'
+
 const builder = (glyph, color, size) => `
 <svg
   fill-rule="evenodd"
@@ -14,6 +16,8 @@ const builder = (glyph, color, size) => `
 >
   ${glyphs[glyph]}
 </svg>`;
+
+const hackClubColors = theme.colors;
 
 const glyphs = {
     analytics: `
@@ -1519,9 +1523,12 @@ export default async function handler(request, response) {
     let { color, glyph } = request.query;
     if (color.startsWith('color:')) color = color.substring(6);
     if (glyph.startsWith('glyph:')) glyph = glyph.substring(6);
-    response.setHeader('Content-Type', 'image/svg+xml');
-    if (color.startsWith('0x') && color.length === 8) color = '#' + color.substring(2);
     if (glyph.endsWith('.svg')) glyph = glyph.substring(0, glyph.length - 4);
+
+    if (color.startsWith('hackclub-') && hackClubColors[color.substring(9)]) color = hackClubColors[color.substring(9)];
+    else if (color.startsWith('0x') && color.length === 8) color = '#' + color.substring(2);
+
+    response.setHeader('Content-Type', 'image/svg+xml');
     response.end(IconLibrary.icon(glyph, 256, color));
 }
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1019,6 +1019,11 @@
   resolved "https://registry.yarnpkg.com/@hackclub/icons/-/icons-0.0.5.tgz#12506ff5d29fad488d82c5f09a2514d763cfcf68"
   integrity sha512-1S+9TuY23+ju9Qdks0fJCFJ0fsWZSUxD8j+2Gm0Mosn2lcMZfRotT8cv5d+mhuJZM6lS2nA4I0IbzR0ODeUzcg==
 
+"@hackclub/theme@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@hackclub/theme/-/theme-0.3.3.tgz#af4249519489459c0e6f9f50a9caab419495b92e"
+  integrity sha512-+K7jVUArvpziophJCCGB6vlQ7uvsm6VQnUnhHSMnF22s681Wgv6M0w12lUJBOevTu3KtgJVCmYlY888uvdaLvQ==
+
 "@hapi/accept@5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.1.tgz#068553e867f0f63225a506ed74e899441af53e10"


### PR DESCRIPTION
This PR

- Improves API docs
- Adds support for Hack Club theme colors prefixed with `hackclub-`, such as `hackclub-green`