### PR TITLE
fix/default props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1573,10 +1573,4 @@ Icon.propTypes = {
   size: PropTypes.number,
 };
 
-Icon.defaultProps = {
-  is: "svg",
-  glyph: "like",
-  size: 32,
-};
-
 export default Icon;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1533,15 +1533,15 @@ export const glyphs = {
 export const glyphNames = Object.keys(glyphs);
 
 type Props<T> = {
-  is?: Function | T | string;
+  is?: React.FunctionComponent | T | string;
   glyph?: keyof typeof glyphs;
   size?: number;
 };
 
 function Icon<T extends React.ElementType = "svg">({
-  is: Component,
-  size,
-  glyph,
+  is: Component = "svg",
+  size = 32,
+  glyph = "like",
   ...props
 }: Props<T> & React.ComponentPropsWithoutRef<T>) {
   return (


### PR DESCRIPTION
Applications making use of this `@hackclub/icons` package were getting warnings like these
<img width="532" alt="image" src="https://github.com/user-attachments/assets/38329c89-9924-40da-b37d-bb1668b49432">

This PR should fix this warning. 