### PR TITLE
Fixes deadlinks to spectrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `@hackclub/icons`
 
-Hack Club’s icons are a superset of [Spectrum](https://spectrum.chat)’s incredible collection (also published as [`spectrum-icons`](https://github.com/lachlanjc/spectrum-icons)). Designed for use with our [Design System](https://github.com/hackclub/design-system).
+Hack Club’s icons are a superset of [Spectrum](https://github.com/withspectrum/spectrum)’s incredible collection (also published as [`supercons`](https://supercons.vercel.app/)). Designed for use with our [Design System](https://github.com/hackclub/design-system).
 
 [See them all](https://hackclub-icons.now.sh)
 


### PR DESCRIPTION
Fixes #53 
Fix deadlinks to spectrum (now owned by github and link redirects to [github.com](https://github.com/) and the link to the old spectrums-icon name + logo (by [@lachlanjc ](https://lachlanjc.com/)).